### PR TITLE
remove min-h-screen classes causing footer visibility issues

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
 
   if (!isConnected) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-background via-background to-background dark:from-background dark:via-muted dark:to-background flex items-center justify-center p-4 animate-fade-in particle-bg">
+      <div className="bg-gradient-to-br from-background via-background to-background dark:from-background dark:via-muted dark:to-background flex items-center justify-center p-4 animate-fade-in particle-bg">
         <div className="bg-card border-2 border-primary/30 rounded-3xl shadow-2xl p-8 max-w-md w-full text-center backdrop-blur-sm animate-slide-up relative glow-border">
           <div className="absolute top-4 right-4">
             <ThemeToggle />
@@ -39,7 +39,7 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background to-background dark:from-background dark:via-muted dark:to-background p-4 animate-fade-in particle-bg">
+    <div className="bg-gradient-to-br from-background via-background to-background dark:from-background dark:via-muted dark:to-background p-4 animate-fade-in particle-bg">
       <div className="max-w-5xl mx-auto">
         <header className="text-center mb-8 relative">
           <div className="absolute top-0 right-0">


### PR DESCRIPTION
small UI fix:

footer wasn't visible unless user scrolled down even at 10% zoom and massive white space below the 'form'

page content divs were using `min-h-screen` 

this forced them to take up the whole screen height which pushed the footer below the viewport

removed `min-h-screen` from page content divs

this allows the footer to be visible regardless of zoom level

the layout container already ensures the page fills the viewport because the body element has `min-h-screen flex flex-col`

this creates a full-height flexbox container that properly manages space distribution